### PR TITLE
Component organization and style

### DIFF
--- a/src/app/components/advocates/advocate-search-table.tsx
+++ b/src/app/components/advocates/advocate-search-table.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Advocate } from "@/app/lib/types";
+
+export default function AdvocateSearchTable() {
+  const [advocates, setAdvocates] = useState<Advocate[]>([]);
+  const [filteredAdvocates, setFilteredAdvocates] = useState<Advocate[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const searchTermInputRef = useRef<HTMLInputElement>(null);
+  const [isDataLoading, setIsDataLoading] = useState(true);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setIsDataLoading(true);
+    fetch("/api/advocates").then((response) => {
+      response.json().then((jsonResponse) => {
+        setAdvocates(jsonResponse.data);
+        setFilteredAdvocates(jsonResponse.data);
+        setIsDataLoading(false);
+      });
+    });
+  }, []);
+
+  const onSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchTermValue = e.target.value;
+    const loweredSearchTermValue = searchTermValue.toLowerCase();
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(() => {
+      setSearchTerm(searchTermValue);
+
+      const filteredAdvocates = advocates.filter((advocate) => {
+        const advocateFullName = `${advocate.firstName} ${advocate.lastName}`;
+
+        return (
+          advocateFullName.toLowerCase().includes(loweredSearchTermValue) ||
+          advocate.city.toLowerCase().includes(loweredSearchTermValue) ||
+          advocate.degree.toLowerCase().includes(loweredSearchTermValue) ||
+          advocate.specialties.some((s) =>
+            s.toLowerCase().includes(loweredSearchTermValue)
+          ) ||
+          advocate.yearsOfExperience.toString().includes(loweredSearchTermValue)
+        );
+      });
+
+      setFilteredAdvocates(filteredAdvocates);
+    }, 300);
+  };
+
+  const onResetSearchClick = () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    setFilteredAdvocates(advocates);
+    setSearchTerm("");
+
+    // Reset the input element to empty
+    const inputEl = searchTermInputRef.current;
+
+    if (!inputEl) return;
+
+    inputEl.value = "";
+  };
+
+  return (
+    <>
+      <div>
+        <p>Search</p>
+        <p>Searching for: {searchTerm}</p>
+        <input
+          ref={searchTermInputRef}
+          style={{ border: "1px solid black" }}
+          onChange={onSearchInputChange}
+        />
+        <button onClick={onResetSearchClick}>Reset Search</button>
+      </div>
+      <br />
+      <br />
+      {isDataLoading ? (
+        <div>
+          <p>Loading...</p>
+        </div>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>First Name</th>
+              <th>Last Name</th>
+              <th>City</th>
+              <th>Degree</th>
+              <th>Specialties</th>
+              <th>Years of Experience</th>
+              <th>Phone Number</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredAdvocates.map((advocate) => {
+              return (
+                <tr key={`${advocate.id}`}>
+                  <td>{advocate.firstName}</td>
+                  <td>{advocate.lastName}</td>
+                  <td>{advocate.city}</td>
+                  <td>{advocate.degree}</td>
+                  <td>
+                    {advocate.specialties.map((s) => (
+                      <div key={`${advocate.id}_${s}`}>{s}</div>
+                    ))}
+                  </td>
+                  <td>{advocate.yearsOfExperience}</td>
+                  <td>{advocate.phoneNumber}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </>
+  );
+}

--- a/src/app/components/advocates/advocate-search-table.tsx
+++ b/src/app/components/advocates/advocate-search-table.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useRef, useState } from "react";
 import { Advocate } from "@/app/lib/types";
 
+const headerColClassNames =
+  "px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-700";
+
 export default function AdvocateSearchTable() {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);
   const [filteredAdvocates, setFilteredAdvocates] = useState<Advocate[]>([]);
@@ -64,57 +67,62 @@ export default function AdvocateSearchTable() {
   };
 
   return (
-    <>
-      <div>
-        <p>Search</p>
-        <p>Searching for: {searchTerm}</p>
-        <input
-          ref={searchTermInputRef}
-          style={{ border: "1px solid black" }}
-          onChange={onSearchInputChange}
-        />
-        <button onClick={onResetSearchClick}>Reset Search</button>
-      </div>
-      <br />
-      <br />
-      {isDataLoading ? (
+    <div className="px-6 flex flex-col">
+      <div className="self-center w-full max-w-[1536px]">
         <div>
-          <p>Loading...</p>
+          <input
+            ref={searchTermInputRef}
+            style={{ border: "1px solid black" }}
+            onChange={onSearchInputChange}
+            placeholder="search..."
+          />
+          <button className="ml-2" onClick={onResetSearchClick}>
+            <span className="font-semibold hover:text-red-700">X</span>
+          </button>
         </div>
-      ) : (
-        <table>
-          <thead>
-            <tr>
-              <th>First Name</th>
-              <th>Last Name</th>
-              <th>City</th>
-              <th>Degree</th>
-              <th>Specialties</th>
-              <th>Years of Experience</th>
-              <th>Phone Number</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredAdvocates.map((advocate) => {
-              return (
-                <tr key={`${advocate.id}`}>
-                  <td>{advocate.firstName}</td>
-                  <td>{advocate.lastName}</td>
-                  <td>{advocate.city}</td>
-                  <td>{advocate.degree}</td>
-                  <td>
-                    {advocate.specialties.map((s) => (
-                      <div key={`${advocate.id}_${s}`}>{s}</div>
-                    ))}
-                  </td>
-                  <td>{advocate.yearsOfExperience}</td>
-                  <td>{advocate.phoneNumber}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
-    </>
+        <br />
+        <br />
+        {isDataLoading ? (
+          <div>
+            <p>Loading...</p>
+          </div>
+        ) : (
+          <table className="min-w-full table-auto">
+            <thead className="bg-gray-100">
+              <tr className="border-b border-gray-300">
+                <th className={headerColClassNames}>First Name</th>
+                <th className={headerColClassNames}>Last Name</th>
+                <th className={headerColClassNames}>City</th>
+                <th className={headerColClassNames}>Degree</th>
+                <th className={headerColClassNames}>Specialties</th>
+                <th className={headerColClassNames}>Years of Experience</th>
+                <th className={headerColClassNames}>Phone Number</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 text-sm">
+              {filteredAdvocates.map((advocate) => {
+                return (
+                  <tr key={`${advocate.id}`} className="hover:bg-gray-50">
+                    <td className="px-4 py-2">{advocate.firstName}</td>
+                    <td className="px-4 py-2">{advocate.lastName}</td>
+                    <td className="px-4 py-2">{advocate.city}</td>
+                    <td className="px-4 py-2">{advocate.degree}</td>
+                    <td className="px-4 py-2 align-top">
+                      <ul className="list-disc pl-5 space-y-1">
+                        {advocate.specialties.map((s) => (
+                          <li key={`${advocate.id}_${s}`}>{s}</li>
+                        ))}
+                      </ul>
+                    </td>
+                    <td className="px-4 py-2">{advocate.yearsOfExperience}</td>
+                    <td className="px-4 py-2">{advocate.phoneNumber}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,12 @@ import AdvocateSearchTable from "./components/advocates/advocate-search-table";
 
 export default async function Home() {
   return (
-    <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
+    <main>
+      <div className="mb-12 p-6 bg-green-800">
+        <div className="mx-auto max-w-[1536px]">
+          <h1 className="text-white text-4xl">Solace Advocates</h1>
+        </div>
+      </div>
       <AdvocateSearchTable />
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,105 +1,12 @@
-"use client";
+import AdvocateSearchTable from "./components/advocates/advocate-search-table";
 
-import { useEffect, useRef, useState } from "react";
-import { Advocate } from "./lib/types";
-
-export default function Home() {
-  const [advocates, setAdvocates] = useState<Advocate[]>([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState<Advocate[]>([]);
-  const [searchTerm, setSearchTerm] = useState("");
-  const searchTermInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
-    });
-  }, []);
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTermValue = e.target.value;
-    const loweredSearchTermValue = searchTermValue.toLowerCase();
-
-    setSearchTerm(searchTermValue);
-
-    const filteredAdvocates = advocates.filter((advocate) => {
-      const advocateFullName = `${advocate.firstName} ${advocate.lastName}`;
-
-      return (
-        advocateFullName.toLowerCase().includes(loweredSearchTermValue) ||
-        advocate.city.toLowerCase().includes(loweredSearchTermValue) ||
-        advocate.degree.toLowerCase().includes(loweredSearchTermValue) ||
-        advocate.specialties.some((s) =>
-          s.toLowerCase().includes(loweredSearchTermValue)
-        ) ||
-        advocate.yearsOfExperience.toString().includes(loweredSearchTermValue)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
-  };
-
-  const onClick = () => {
-    setFilteredAdvocates(advocates);
-    setSearchTerm("");
-
-    // Reset the input element to empty
-    const inputEl = searchTermInputRef.current;
-
-    if (!inputEl) return;
-
-    inputEl.value = "";
-  };
-
+export default async function Home() {
   return (
     <main style={{ margin: "24px" }}>
       <h1>Solace Advocates</h1>
       <br />
       <br />
-      <div>
-        <p>Search</p>
-        <p>Searching for: {searchTerm}</p>
-        <input
-          ref={searchTermInputRef}
-          style={{ border: "1px solid black" }}
-          onChange={onChange}
-        />
-        <button onClick={onClick}>Reset Search</button>
-      </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
-              <tr key={`${advocate.id}`}>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div key={`${advocate.id}_${s}`}>{s}</div>
-                  ))}
-                </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <AdvocateSearchTable />
     </main>
   );
 }


### PR DESCRIPTION
In this PR:

* separate search bar and table into separate components
* fixed hydration error due to no <tr> tag inside <thead>
* added debounce to search input to prevent unnecessary filtering computation
* center content on page with a max width
* remove unnecessary "Search" and "Searching for: ..." p tags
* Make reset button a hoverable "X" instead of "Reset Search" text
* separate headers from table with background and border
* separate table rows with borders
* add slight gray background when hovering over a row
* make specialties an unordered list with bullet points